### PR TITLE
Don't request a breaking version of postgres

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/SkylerLipthay/schemamama_postgres"
 
 [dependencies]
 schemamama = ">=0.1"
-postgres = ">=0.13"
+postgres = ">=0.13, <=0.15"


### PR DESCRIPTION
Before, it would try to compile with postgres `0.17` and break with errors like this:

```
error[E0412]: cannot find type `GenericConnection` in crate `postgres`
  --> src/lib.rs:28:31
   |
28 |     connection: &'a postgres::GenericConnection,
   |                               ^^^^^^^^^^^^^^^^^ not found in `postgres`

error[E0412]: cannot find type `GenericConnection` in crate `postgres`
  --> src/lib.rs:34:42
   |
34 |     pub fn new(connection: &'a postgres::GenericConnection) -> PostgresAdapter<'a> {
   |                                          ^^^^^^^^^^^^^^^^^ not found in `postgres`

error[E0412]: cannot find type `GenericConnection` in crate `postgres`
  --> src/lib.rs:40:35
   |
40 |         connection: &'a postgres::GenericConnection,
   |                                   ^^^^^^^^^^^^^^^^^ not found in `postgres`

error[E0603]: module `transaction` is private
 --> src/lib.rs:5:15
  |
5 | use postgres::transaction::Transaction;
  |               ^^^^^^^^^^^
```

Now, it compiles using 0.15 instead.